### PR TITLE
Novas traduções reference/session/functions

### DIFF
--- a/pt_BR/reference/session/functions/session-abort.xml
+++ b/pt_BR/reference/session/functions/session-abort.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 336604 Maintainer: none Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-abort">
+ <refnamediv>
+  <refname>session_abort</refname>
+  <refpurpose>Descarta as alterações no array da sessão e encerra a sessão</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>session_abort</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   <function>session_abort</function> encerra a sessão sem salvar
+   dados. Consequentemente, os valores originais da sessão são mantidos.
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><varname>$_SESSION</varname></member>
+    <member>
+     Diretiva de
+     configuração <link linkend="ini.session.auto-start">session.auto_start</link>
+    </member>
+    <member><function>session_start</function></member>
+    <member><function>session_reset</function></member>
+    <member><function>session_commit</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/pt_BR/reference/session/functions/session-register-shutdown.xml
+++ b/pt_BR/reference/session/functions/session-register-shutdown.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 327572 Maintainer: none Status: ready -->
+
+<refentry xml:id="function.session-register-shutdown" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>session_register_shutdown</refname>
+  <refpurpose>Função de finalização da sessão</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>session_register_shutdown</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Registra <function>session_write_close</function> como uma função de finalização.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Dispara um <constant>E_WARNING</constant> se o processo de registrar a função
+   falhar.
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/pt_BR/reference/session/functions/session-reset.xml
+++ b/pt_BR/reference/session/functions/session-reset.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 336604 Maintainer: none Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-reset">
+ <refnamediv>
+  <refname>session_reset</refname>
+  <refpurpose>Reinicializa um array de sessão com os valores originais</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>session_reset</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   <function>session_reset</function> reinicializa uma sessão com
+   os valores originais salvos no armazenamento de sessão. Esta função requer uma sessão ativa e
+   descarta as alterações em $_SESSION.
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><varname>$_SESSION</varname></member>
+    <member>
+     A diretiva de
+     configuração <link linkend="ini.session.auto-start">session.auto_start</link>
+    </member>
+    <member><function>session_start</function></member>
+    <member><function>session_abort</function></member>
+    <member><function>session_commit</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/pt_BR/reference/session/functions/session-status.xml
+++ b/pt_BR/reference/session/functions/session-status.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 320272 Maintainer: none Status: ready -->
+
+<refentry xml:id="function.session-status" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>session_status</refname>
+  <refpurpose>Retorna o status atual da sessão</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description"><!-- {{{ -->
+  &reftitle.description;
+  <methodsynopsis role="procedural">
+   <type>int</type><methodname>session_status</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   <function>session_status</function> é usada para retornar o status atual da sessão.
+  </para>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="returnvalues"><!-- {{{ -->
+  &reftitle.returnvalues;
+  <para>
+   <itemizedlist>
+    <listitem>
+     <simpara><constant>PHP_SESSION_DISABLED</constant> se as sessões estiverem desabilitadas.</simpara>
+    </listitem>
+    <listitem>
+     <simpara><constant>PHP_SESSION_NONE</constant> se as sessões estiverem habilitadas, mas nenhuma existir.</simpara>
+    </listitem>
+    <listitem>
+     <simpara><constant>PHP_SESSION_ACTIVE</constant> se as sessões estiverem habilitadas, e uma existir.</simpara>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </refsect1><!-- }}} -->
+ 
+ <refsect1 role="seealso"><!-- {{{ -->
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>session_start</function></member>
+  </simplelist>
+ </refsect1><!-- }}} -->
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->
+


### PR DESCRIPTION
Foi traduzido os arquivos de reference/session/functions que estavam sem tradução:
session-abort.xml
session-register-shutdown.xml
session-reset.xml
session-status.xml